### PR TITLE
ACKs

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -61,7 +61,6 @@ const send = (message, options) => {
   enqueue(data)
 
   if (get_queue().length == 1) {
-    debug && console.log("send - only 1 msg in queue")
     send_next()
   }
 }
@@ -78,7 +77,6 @@ const get_next_id = () => {
 const send_next = () => {
   if (resend_timer == null) {
     const queue = get_queue()
-    debug && console.log("send_next, queue.length: " + queue.length)
     if (queue.length > 0) {
       try {
         if (is_message_expired(queue[0])) {

--- a/source/app.js
+++ b/source/app.js
@@ -49,7 +49,7 @@ const send = (message, options) => {
   options.timeout = options.timeout || 2592000000 // 30 days
   // Create the data object
   const data = {
-    _asap_id: Math.floor(Math.random() * 10000000000), // Random 10-digit number
+    _asap_id: get_next_id(),
     _asap_created: now,
     _asap_timeout: options.timeout,
     _asap_message: message,

--- a/source/companion.js
+++ b/source/companion.js
@@ -49,7 +49,7 @@ const send = (message, options) => {
   options.timeout = options.timeout || 2592000000 // 30 days
   // Create the data object
   const data = {
-    _asap_id: Math.floor(Math.random() * 10000000000), // Random 10-digit number
+    _asap_id: get_next_id(),
     _asap_created: now,
     _asap_timeout: options.timeout,
     _asap_message: message,

--- a/source/companion.js
+++ b/source/companion.js
@@ -24,8 +24,6 @@ const enqueue = (data) => {
   // Add the message to the queue
   const queue = get_queue()
   queue.push(data)
-  debug && console.log(data)
-  debug && console.log(queue)
   // Write the queue to disk
   persist_queue(queue)
   // Attempt to send all data
@@ -79,7 +77,6 @@ const get_next_id = () => {
 const send_next = () => {
   if (resend_timer == null) {
     const queue = get_queue()
-    debug && console.log("send_next, queue.length: " + queue.length)
     if (queue.length > 0) {
       try {
         if (is_message_expired(queue[0])) {
@@ -106,7 +103,6 @@ const send_all = () => {
 }
 
 const persist_queue = (queue) => {
-  debug && console.log("persist_queue: " + queue)
   try {
     localStorage.setItem("_asap_queue", JSON.stringify(queue))
   } catch (error) {


### PR DESCRIPTION
This PR implementes most of what was discussed in https://github.com/dillpixel/fitbit-asap/issues/2.

The basic throughput test passes. We should write some more tests definitely, see https://github.com/dillpixel/fitbit-asap/issues/7.

- the API is kept intact
- messages are sent synchronously - introducing send_next() instead of send_all()
- ACKs are implemented as a boolean on data object
- after sending a message, ASAP waits 5 seconds for an ACK and eventually resends the message. This is handled by a global timer, which is being set and cleared by set_resend_timer() and clear_resend_timer()
- message is dequeued only after successfully receiving an ACK for it
- onmessage is only triggered if we didn't already receive a message with same or higher id
- send_next() can be called multiple times at once, ensures only one message is being sent at once. This is important during startup where we usually send_next() twice at a time.
- message IDs are incremental, starting from a random seed, via get_next_id()

- message expiration is handled via is_message_expired(). Does NOT throw an error on expiration. This is a TODO, I've opened up issue https://github.com/dillpixel/fitbit-asap/issues/8 
